### PR TITLE
docs: Add usage instructions and example for gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # aigit
 AI Git Commit Assistant is a command-line tool that streamlines the git commit process by automatically generating meaningful and standardized commit messages. 
+
+# Usage
+
+- gemini
+
+```
+export GEMINI_API_KEY=AIzaSyCb56xxxxx
+
+✗ go run main.go commit
+feat: Add Gemini API integration for commit message generation
+
+This commit introduces the integration of the Gemini API to generate
+commit messages based on the provided diff. The code now uses a
+prompt to send a diff to the Gemini API, gets the output, and prints
+the generated commit message.%
+
+
+```


### PR DESCRIPTION
This commit adds usage instructions and an example for using the gemini API for commit message generation. It also follows the convention commit standards and includes a body to provide more details about the changes.