### PR TITLE
feat(ci): Add build configuration and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ go.work.sum
 # env file
 .env
 .idea/
+
+
+build/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+BINARY_NAME=aigit
+VERSION=0.0.2
+
+# Build directories
+BUILD_DIR=build
+MACOS_AMD64=$(BUILD_DIR)/$(BINARY_NAME)_darwin_amd64_$(VERSION)
+MACOS_ARM64=$(BUILD_DIR)/$(BINARY_NAME)_darwin_arm64_$(VERSION)
+WINDOWS_AMD64=$(BUILD_DIR)/$(BINARY_NAME)_windows_amd64_$(VERSION).exe
+
+.PHONY: all clean build-all build-macos-amd64 build-macos-arm64 build-windows
+
+all: build-all
+
+build-all: clean macos-amd64 macos-arm64 windows
+	@echo "Build complete! Binaries are in the $(BUILD_DIR) directory"
+
+macos-amd64:
+	@mkdir -p $(BUILD_DIR)
+	GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o $(MACOS_AMD64) main.go
+
+macos-arm64:
+	@mkdir -p $(BUILD_DIR)
+	GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -o $(MACOS_ARM64) main.go
+
+windows:
+	@mkdir -p $(BUILD_DIR)
+	GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o $(WINDOWS_AMD64) main.go
+
+clean:
+	@rm -rf $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -10,8 +10,13 @@ It's a command-line tool that streamlines the git commit process by automaticall
 
 ### Download the binary
 
+- Go to the [releases page](https://github.com/zzxwill/aigit/releases) and download the binary for your platform.
+
+- Rename the binary to `aigit` and move it to `/usr/local/bin/aigit`.
+
 ```shell
-$ wget https://github.com/zzxwill/aigit/releases/download/v0.0.1/aigit && chmod +x aigit && sudo mv aigit /usr/local/bin/aigit
+$ chmod +x aigit && sudo mv aigit /usr/local/bin/aigit
+```
 
 ### Generate commit message
 


### PR DESCRIPTION
This commit adds a Makefile for building the project with specific binaries for different platforms and updates the.gitignore to include the build directory. The README was updated to provide clearer instructions on downloading the binary. This helps streamline the build process and makes it easier for users to get the tool up and running.