### PR TITLE
feat(llm): add support for Deepseek provider in commit message generation

### DIFF
--- a/llm/model.go
+++ b/llm/model.go
@@ -42,6 +42,7 @@ The commit message should follow these rules:
 3. The body should explain WHAT and WHY (not HOW)
 4. Each line should be less than 72 characters
 5. There should be a line break between the title and the body
+6. Disable markdown formatting
 
 Here's the diff:`
 

--- a/main.go
+++ b/main.go
@@ -261,6 +261,8 @@ func generateMessage(config *llm.Config, diffOutput []byte) (string, error) {
 		commitMessage, err = llm.GenerateDoubaoCommitMessage(string(diffOutput), apiKey, endpoint)
 	case llm.ProviderOpenAI:
 		commitMessage, err = llm.GenerateOpenAICommitMessage(string(diffOutput), apiKey)
+	case llm.ProviderDeepseek:
+		commitMessage, err = llm.GenerateDeepseekCommitMessage(string(diffOutput), apiKey)
 	default:
 		apiKey, err1 := base64.StdEncoding.DecodeString(llm.DefaultApiKey)
 		if err1 != nil {


### PR DESCRIPTION
This commit introduces support for the Deepseek provider in the commit message generation logic. The change allows users to generate commit messages using the Deepseek API, expanding the range of supported LLM providers. This enhancement improves flexibility and aligns with the goal of supporting multiple AI providers for diverse use cases.