### PR TITLE
feat(.github/workflows): Add steps to generate release notes and upload binary files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,12 +59,23 @@ jobs:
           path: artifacts
           merge-multiple: true
           
+      # First, generate the release notes
       - name: Draft Release
+        id: release_drafter
         uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Then, update the release with binary files
+      - name: Upload Release Assets
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
             artifacts/aigit_darwin_amd64
             artifacts/aigit_darwin_arm64
             artifacts/aigit_windows_amd64.exe
+          draft: false
+          body: ${{ steps.release_drafter.outputs.body }}
+          tag_name: ${{ steps.release_drafter.outputs.tag_name }}
+          name: ${{ steps.release_drafter.outputs.name }}


### PR DESCRIPTION
Added steps in the build workflow to first generate release notes using release-drafter/release-drafter@v5. Then, if the ref starts with 'refs/tags/', upload binary files to the release using softprops/action-gh-release@v1, populating the release details from the output of the release drafter step. This streamlines the release process by automating note generation and asset upload.