### PR TITLE
feat(auth): support optional endpoint ID in auth add command

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 	}
 
 	var authAddCmd = &cobra.Command{
-		Use:                   "add [provider] [api_key]",
+		Use:                   "add <provider> <api_key> [endpoint_id]",
 		Short:                 "Add or update API key for a provider",
 		Long:                  "Add or update API key for a provider. Supported providers: openai, gemini, doubao, deepseek",
 		DisableFlagsInUseLine: true,


### PR DESCRIPTION
The auth add command now accepts an optional endpoint_id parameter to allow storing API keys for specific provider endpoints. This enables configuration of multiple API keys for services that support different regional endpoints while maintaining backward compatibility with existing usage.