### PR TITLE
feat(version): add version command and build-time version injection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           go-version: '1.23'
 
+      - name: Get version from tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
       - name: Build Binary
         env:
           GOOS: ${{ matrix.os }}
@@ -35,7 +39,7 @@ jobs:
           if [ "${{ matrix.os }}" == "windows" ]; then
             BINARY_NAME+=".exe"
           fi
-          go build -ldflags="-s -w" -o $BINARY_NAME main.go
+          go build -ldflags "-s -w -X main.Version=${VERSION}" -o $BINARY_NAME main.go
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/main.go
+++ b/main.go
@@ -267,6 +267,27 @@ func main() {
 
 	rootCmd.AddCommand(commitCmd)
 
+	var versionCmd = &cobra.Command{
+		Use:     "version",
+		Aliases: []string{"v", "-v", "-version", "--version"},
+		Short:   "Print the version of aigit",
+		Long:    "Print the current version of the aigit CLI tool.",
+		Run: func(cmd *cobra.Command, args []string) {
+			if Version == "dev" {
+				version, err := exec.Command("git", "describe", "--tags").Output()
+				if err != nil {
+					fmt.Printf("Error retrieving version: %v\n", err)
+					os.Exit(1)
+				}
+				fmt.Printf("%s\n", strings.TrimSpace(string(version)))
+			} else {
+				fmt.Printf("%s\n", Version)
+			}
+		},
+	}
+
+	rootCmd.AddCommand(versionCmd)
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
This commit adds a new version command to the CLI tool that displays the current version, either from build flags or git tags. It also modifies the build workflow to inject the version from git tags during release builds. This provides better version tracking and user visibility of the tool's version.