### PR TITLE
docs(README): Update installation instructions with `go install` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,22 @@ It's a command-line tool that streamlines the git commit process by automaticall
 
 ### Download the binary
 
-- Go to the [releases page](https://github.com/zzxwill/aigit/releases) and download the binary for your platform.
+You can install aigit in one of the following ways:
 
+1. Using `go install`:
+
+```shell
+go install github.com/zzxwill/aigit@latest
+```
+
+```shell
+$ aigit version
+v0.0.8
+```
+
+2. Download from releases:
+
+- Go to the [releases page](https://github.com/zzxwill/aigit/releases) and download the binary for your platform.
 - Rename the binary to `aigit` and move it to `/usr/local/bin/aigit`.
 
 ```shell

--- a/README_CN.md
+++ b/README_CN.md
@@ -15,8 +15,22 @@
 
 ### 下载二进制文件
 
-- 前往 [发布页面](https://github.com/zzxwill/aigit/releases) 下载适合您平台的二进制文件。
+您可以通过以下方式之一安装 aigit：
 
+1. 使用 `go install` (当前版本：v0.0.8)：
+
+```shell
+go install github.com/zzxwill/aigit@latest
+```
+
+```shell
+$ aigit version
+v0.0.8
+```
+
+2. 从发布页面下载：
+
+- 前往 [发布页面](https://github.com/zzxwill/aigit/releases) 下载适合您平台的二进制文件。
 - 将二进制文件重命名为 `aigit` 并移动到 `/usr/local/bin/aigit`。
 
 ```shell
@@ -117,5 +131,3 @@ The following changes were made:
 Enter your choice (press Enter for default): 1
 
 ✅ Successfully committed changes!
-
-```


### PR DESCRIPTION
The README and README_CN files have been updated to include a new installation method using `go install`. This change provides users with an additional, streamlined way to install the tool, enhancing the user experience and making the installation process more flexible. The previous instructions have been retained for users who prefer downloading the binary directly.