### PR TITLE
feat(version): improve version detection logic

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime/debug"
 	"strings"
 
 	"github.com/fatih/color"
@@ -273,16 +274,22 @@ func main() {
 		Short:   "Print the version of aigit",
 		Long:    "Print the current version of the aigit CLI tool.",
 		Run: func(cmd *cobra.Command, args []string) {
-			if Version == "dev" {
-				version, err := exec.Command("git", "describe", "--tags").Output()
-				if err != nil {
-					fmt.Printf("Error retrieving version: %v\n", err)
-					os.Exit(1)
-				}
-				fmt.Printf("%s\n", strings.TrimSpace(string(version)))
-			} else {
-				fmt.Printf("%s\n", Version)
+			if Version != "dev" {
+				fmt.Println(Version)
+				return
 			}
+
+			if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+				fmt.Println(info.Main.Version)
+				return
+			}
+
+			version, err := exec.Command("git", "describe", "--tags").Output()
+			if err != nil {
+				fmt.Println("dev")
+				return
+			}
+			fmt.Printf("%s\n", strings.TrimSpace(string(version)))
 		},
 	}
 


### PR DESCRIPTION
The version command now uses debug.ReadBuildInfo() as the first fallback when Version is "dev" before falling back to git describe. This provides more reliable version detection in development builds and handles cases where git is not available by returning "dev" as a last resort.

Fix #37 