### PR TITLE
chore(workflow): fix failed workflow

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -85,5 +85,5 @@ jobs:
           - Update formula for version ${{ steps.release.outputs.version }}
           - SHA256: ${{ steps.release.outputs.sha256 }}"
 
-            git push
+            git push origin HEAD
           fi


### PR DESCRIPTION
fix the failed to workflow caused by`update-homebrew.yaml`. The [error](https://github.com/agentsdance/aigit/actions/runs/20289117441/job/58269481052#step:5:27) looks like:

```bash
Run git config --local user.email "action@github.com"
  git config --local user.email "action@github.com"
  git config --local user.name "GitHub Action"
  
  git add Formula/aigit.rb
  
  if git diff --staged --quiet; then
    echo "No changes to commit"
  else
    git commit -m "chore: update homebrew formula to v0.1.1
  
  - Update formula for version v0.1.1
  - SHA256: 160cbd4b7cf12c0f80786b9fcc8f2f673d2a1be290cee96ab7dfacb60c5dcd1c"
  
    git push
  fi
  shell: /usr/bin/bash -e {0}
[detached HEAD 4e1cac4] chore: update homebrew formula to v0.1.1
 1 file changed, 4 insertions(+), 4 deletions(-)
fatal: You are not currently on a branch.
To push the history leading to the current (detached HEAD)
state now, use

    git push origin HEAD:<name-of-remote-branch>

Error: Process completed with exit code 128.
```