### PR TITLE
refactor: update default LLM models and simplify Doubao provider config

### DIFF
--- a/llm/config.go
+++ b/llm/config.go
@@ -70,17 +70,11 @@ func (c *Config) Save() error {
 }
 
 func (c *Config) AddProvider(provider, apiKey string, endpoint ...string) error {
-	switch provider {
-	case ProviderDoubao:
-		c.Providers[provider] = Provider{
-			APIKey:   apiKey,
-			Endpoint: endpoint[0],
-		}
-	default:
-		c.Providers[provider] = Provider{
-			APIKey: apiKey,
-		}
+	p := Provider{APIKey: apiKey}
+	if len(endpoint) > 0 {
+		p.Endpoint = endpoint[0]
 	}
+	c.Providers[provider] = p
 	if c.CurrentProvider == "" {
 		c.CurrentProvider = provider
 	}
@@ -104,14 +98,35 @@ func (c *Config) GetAPIKey(provider string) (string, error) {
 
 func (c *Config) ListProviders() []string {
 	providers := make([]string, 0, len(c.Providers))
-	for k := range c.Providers {
+	for k, p := range c.Providers {
+		entry := fmt.Sprintf("%s(%s)", k, providerModel(k, p))
 		if k == c.CurrentProvider {
-			providers = append(providers, k+" *default")
-		} else {
-			providers = append(providers, k)
+			entry += " *default"
 		}
+		providers = append(providers, entry)
 	}
 	return providers
+}
+
+// providerModel returns the model a provider will use: the configured
+// endpoint/model if set, otherwise the provider's default model.
+func providerModel(provider string, p Provider) string {
+	if p.Endpoint != "" {
+		return p.Endpoint
+	}
+	switch provider {
+	case ProviderGemini:
+		return geminiModel
+	case ProviderOpenAI:
+		return openaiModel
+	case ProviderDeepseek:
+		return deepseekModel
+	case ProviderQwen:
+		return qwenModel
+	case ProviderDoubao:
+		return doubaoModel
+	}
+	return "unknown"
 }
 
 // GetMessageGenerator returns a MessageGenerator instance based on the current provider.

--- a/llm/model.go
+++ b/llm/model.go
@@ -28,10 +28,11 @@ const (
 	ProviderQwen     = "qwen"
 
 	// Model constants
-	geminiModel   = "gemini-pro"
-	deepseekModel = "deepseek-chat"
-	openaiModel   = "chatgpt-4o-latest"
+	geminiModel   = "gemini-3.5-flash"
+	deepseekModel = "deepseek-v4-flash-260425"
+	openaiModel   = "gpt-5.4-mini"
 	qwenModel     = "qwen-plus"
+	doubaoModel   = "doubao-seed-2-0-lite-260428"
 )
 
 const (
@@ -205,7 +206,7 @@ func generateOpenAICommitMessage(diff, apiKey string) (string, error) {
 		Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
 			openai.UserMessage(prompt),
 		}),
-		Model: openai.F(openai.ChatModelGPT4o),
+		Model: openai.F(openai.ChatModel(openaiModel)),
 	})
 	if err != nil {
 		return "", fmt.Errorf("generating commit message: %w", err)
@@ -219,6 +220,12 @@ func generateOpenAICommitMessage(diff, apiKey string) (string, error) {
 }
 
 func generateDoubaoCommitMessage(diff, apiKey string, endpointId string) (string, error) {
+	// An Ark endpoint ID (ep-xxx) or model ID may be supplied; fall back to
+	// the default model when neither is configured.
+	if endpointId == "" {
+		endpointId = doubaoModel
+	}
+
 	client := arkruntime.NewClientWithApiKey(
 		apiKey,
 	)

--- a/llm/model_live_test.go
+++ b/llm/model_live_test.go
@@ -1,0 +1,31 @@
+package llm
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// Live test against the Ark runtime. Skipped unless ARK_API_KEY and
+// ARK_MODEL_ID are set: go test -v -run TestGenerateDoubaoCommitMessageLive ./llm
+func TestGenerateDoubaoCommitMessageLive(t *testing.T) {
+	apiKey := os.Getenv("ARK_API_KEY")
+	modelID := os.Getenv("ARK_MODEL_ID")
+	if apiKey == "" || modelID == "" {
+		t.Skip("ARK_API_KEY / ARK_MODEL_ID not set")
+	}
+
+	diff, err := exec.Command("git", "diff", "HEAD", "--", "model.go").Output()
+	if err != nil || len(diff) == 0 {
+		t.Fatalf("getting diff: %v (len=%d)", err, len(diff))
+	}
+
+	msg, err := generateDoubaoCommitMessage(string(diff), apiKey, modelID)
+	if err != nil {
+		t.Fatalf("generateDoubaoCommitMessage: %v", err)
+	}
+	if msg == "" {
+		t.Fatal("empty commit message returned")
+	}
+	t.Logf("generated commit message:\n%s", msg)
+}

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 	authAddCmd := &cobra.Command{
 		Use:                   "add <provider> <api_key> [endpoint_id]",
 		Short:                 "Add or update API key for a provider",
-		Long:                  "Add or update API key for a provider. Supported providers: openai, gemini, doubao, deepseek, qwen. endpoint_id is required for Doubao provider",
+		Long:                  "Add or update API key for a provider. Supported providers: openai, gemini, doubao, deepseek, qwen. For Doubao, an optional endpoint or model ID may be given (defaults to the built-in model)",
 		DisableFlagsInUseLine: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) < 2 {
@@ -77,18 +77,8 @@ func main() {
 
 			// Validate provider
 			switch provider {
-			case llm.ProviderOpenAI, llm.ProviderGemini, llm.ProviderDeepseek, llm.ProviderQwen:
-				if err := config.AddProvider(provider, apiKey); err != nil {
-					fmt.Printf("Error saving config: %v\n", err)
-					os.Exit(1)
-				}
-			case llm.ProviderDoubao:
-				if len(args) < 3 {
-					color.Red("Endpoint ID is required for Doubao provider")
-					color.Red("Please run `aigit auth add doubao <api_key> <endpoint_id>`")
-					os.Exit(1)
-				}
-				if err := config.AddProvider(provider, apiKey, args[2]); err != nil {
+			case llm.ProviderOpenAI, llm.ProviderGemini, llm.ProviderDeepseek, llm.ProviderQwen, llm.ProviderDoubao:
+				if err := config.AddProvider(provider, apiKey, args[2:]...); err != nil {
 					fmt.Printf("Error saving config: %v\n", err)
 					os.Exit(1)
 				}


### PR DESCRIPTION
## Summary

- Update out-of-date default model IDs: `gemini-pro` (retired, returns 404) → `gemini-3.5-flash`, `chatgpt-4o-latest` / hardcoded GPT-4o (deprecated Feb 2026) → `gpt-5.4-mini`, `deepseek-chat` → `deepseek-v4-flash-260425`
- Add a `doubaoModel` default (`doubao-seed-2-0-lite-260428`, latest Doubao Seed 2.0 Lite) so Doubao is no longer a special case — `aigit auth add doubao <api_key>` now works without a mandatory endpoint ID; an Ark endpoint (`ep-xxx`) or model ID can still be passed as an optional override
- Simplify `AddProvider` to handle the optional endpoint uniformly across all providers
- `aigit auth list` now shows the resolved model per provider, e.g. `doubao(doubao-seed-2-0-lite-260428) *default`
- Add an env-gated live integration test for Doubao generation (`ARK_API_KEY`/`ARK_MODEL_ID`)

## Test plan

- `go build ./...` and `gofmt` clean
- Live test passes: `ARK_API_KEY=... ARK_MODEL_ID=doubao-seed-2-0-lite-260428 go test -run TestGenerateDoubaoCommitMessageLive ./llm`
- Verified the real CLI end-to-end: with a Doubao provider configured without an endpoint, `aigit commit` falls back to the default model and generates a valid Conventional Commits message

🤖 Generated with [Claude Code](https://claude.com/claude-code)