### PR TITLE
feat(cli): add automatic version update check

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/manifoldco/promptui"
@@ -17,10 +18,26 @@ import (
 var Version = "dev"
 
 func main() {
+	var updateNotice <-chan string
 	rootCmd := &cobra.Command{
 		Use:   "aigit",
 		Short: "Generate git commit message including title and body",
 		Long:  `AI Git Commi streamlines the git commit process by automatically generating meaningful and standardized commit messages.`,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			updateNotice = startUpdateCheck(Version)
+		},
+		PersistentPostRun: func(cmd *cobra.Command, args []string) {
+			select {
+			case notice := <-updateNotice:
+				if notice != "" {
+					fmt.Println(notice)
+				}
+			// Slightly longer than the update check's HTTP timeout so the
+			// once-per-day refresh can finish and persist its state file;
+			// cached runs deliver instantly.
+			case <-time.After(3 * time.Second):
+			}
+		},
 	}
 
 	authCmd := &cobra.Command{

--- a/update.go
+++ b/update.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+)
+
+const (
+	updateCheckInterval = 24 * time.Hour
+	latestReleaseURL    = "https://api.github.com/repos/agentsdance/aigit/releases/latest"
+)
+
+// updateCheckState is persisted to ~/.aigit/update-check.json so the
+// GitHub API is queried at most once per updateCheckInterval.
+type updateCheckState struct {
+	CheckedAt     time.Time `json:"checked_at"`
+	LatestVersion string    `json:"latest_version"`
+}
+
+// startUpdateCheck looks for a newer aigit release in the background while
+// the main command runs. The returned channel always delivers exactly one
+// value: an upgrade notice, or "" when no upgrade is available.
+func startUpdateCheck(current string) <-chan string {
+	ch := make(chan string, 1)
+	go func() {
+		ch <- updateNotice(current)
+	}()
+	return ch
+}
+
+func updateNotice(current string) string {
+	// Source builds report "dev" and have no release to compare against.
+	if current == "dev" || os.Getenv("AIGIT_NO_UPDATE_CHECK") != "" || os.Getenv("CI") != "" {
+		return ""
+	}
+
+	latest, err := latestVersion()
+	if err != nil || latest == "" {
+		return ""
+	}
+	if !versionLess(current, latest) {
+		return ""
+	}
+
+	return fmt.Sprintf("\n%s %s → %s\nTo upgrade: brew upgrade aigit  (or: go install github.com/zzxwill/aigit@latest)",
+		color.YellowString("A new release of aigit is available:"),
+		strings.TrimPrefix(current, "v"),
+		strings.TrimPrefix(latest, "v"))
+}
+
+// latestVersion returns the most recent release tag, served from the local
+// state file when it is fresh enough, otherwise from the GitHub API.
+func latestVersion() (string, error) {
+	stateFile := updateStateFile()
+	if stateFile != "" {
+		if st, err := readUpdateState(stateFile); err == nil && time.Since(st.CheckedAt) < updateCheckInterval {
+			return st.LatestVersion, nil
+		}
+	}
+
+	tag, err := fetchLatestTag()
+	if err != nil {
+		return "", err
+	}
+	if stateFile != "" {
+		writeUpdateState(stateFile, tag)
+	}
+	return tag, nil
+}
+
+func updateStateFile() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	dir := filepath.Join(homeDir, ".aigit")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return ""
+	}
+	return filepath.Join(dir, "update-check.json")
+}
+
+func readUpdateState(path string) (updateCheckState, error) {
+	var st updateCheckState
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return st, err
+	}
+	err = json.Unmarshal(data, &st)
+	return st, err
+}
+
+func writeUpdateState(path, latest string) {
+	data, err := json.Marshal(updateCheckState{CheckedAt: time.Now(), LatestVersion: latest})
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0o600)
+}
+
+func fetchLatestTag() (string, error) {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(latestReleaseURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %s", resp.Status)
+	}
+
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", err
+	}
+	return release.TagName, nil
+}
+
+// versionLess reports whether version a is older than version b. Versions
+// are compared numerically segment by segment ("v" prefix and pre-release
+// suffixes like "-rc1" are ignored), e.g. v0.0.9 < v0.0.10.
+func versionLess(a, b string) bool {
+	as := versionSegments(a)
+	bs := versionSegments(b)
+	for i := 0; i < len(as) || i < len(bs); i++ {
+		var av, bv int
+		if i < len(as) {
+			av = as[i]
+		}
+		if i < len(bs) {
+			bv = bs[i]
+		}
+		if av != bv {
+			return av < bv
+		}
+	}
+	return false
+}
+
+func versionSegments(v string) []int {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	parts := strings.Split(v, ".")
+	segs := make([]int, 0, len(parts))
+	for _, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			break
+		}
+		segs = append(segs, n)
+	}
+	return segs
+}


### PR DESCRIPTION
## Summary

- On every aigit invocation, a background goroutine checks GitHub's latest release and prints an upgrade notice after the command finishes if a newer version is available
- The result is cached in `~/.aigit/update-check.json`, so the GitHub API is hit at most once per 24 hours; cached runs add zero latency
- Fails silently on network errors / API rate limits; skipped entirely for `dev` builds, in CI, or when `AIGIT_NO_UPDATE_CHECK` is set
- Version comparison ignores the `v` prefix and git-describe suffixes (`v0.1.1-7-gabc1234` compares as `0.1.1`), and compares numerically so `v0.0.9 < v0.0.10`

## Test plan

- Verified with stamped builds against a seeded cache: `v0.1.1` and `v0.1.1-7-ga98bc1b` show the notice, `v0.1.2` stays quiet
- Verified silent behavior under GitHub API rate limiting
- `go build ./...` and `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)