### PR TITLE
docs: refresh READMEs; add version-compare tests and lint cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@ It's a command-line tool that streamlines the git commit process by automaticall
 
 ## Supported 🤖 AI Providers
 
-- [OpenAI](https://openai.com/)
-- [DeepSeek](https://deepseek.com/)
-- [Doubao (豆包)](https://www.volcengine.com/product/doubao) - Built-in, you don't need to bring your own key
-- [Gemini](https://gemini.google.com/)
+| Provider | Default model |
+|---|---|
+| [OpenAI](https://openai.com/) | `gpt-5.4-mini` |
+| [DeepSeek](https://deepseek.com/) | `deepseek-v4-flash-260425` |
+| [Doubao (豆包)](https://www.volcengine.com/product/doubao) - Built-in, you don't need to bring your own key | `doubao-seed-2-0-lite-260428` |
+| [Gemini](https://gemini.google.com/) | `gemini-3.5-flash` |
+| [Qwen (通义千问)](https://www.aliyun.com/product/tongyi) | `qwen-plus` |
 
 ## Getting Started
 
@@ -106,13 +109,13 @@ Enter your choice (press Enter for default):
 $ aigit auth add gemini AIzaSyCb56bjWn02e2v4s_TxHMDnHbSJQSx_tu8
 Successfully added API key for gemini
 
-$ aigit auth add doubao 6e3e438c-a380-4ed5-b597-e01cb82bc4df ep-20250110202503-fdkgq
+$ aigit auth add doubao 6e3e438c-a380-4ed5-b597-e01cb82bc4df
 Successfully added API key for doubao
 
 $ aigit auth ls
 Configured providers:
-  gemini *default
-  doubao
+  gemini(gemini-3.5-flash) *default
+  doubao(doubao-seed-2-0-lite-260428)
 
 $ aigit commit
 
@@ -165,3 +168,16 @@ Enter your choice (press Enter for default): 1
 ✅ Successfully committed changes!
 
 ```
+
+For Doubao, the provider uses the built-in default model. You can optionally pass an
+[Ark inference endpoint ID](https://www.volcengine.com/docs/82379/1099522) (`ep-xxx`) or a model ID to override it:
+
+```shell
+$ aigit auth add doubao <api_key> ep-20250110202503-fdkgq
+```
+
+## Update check
+
+aigit checks for new releases in the background (at most once every 24 hours, cached
+in `~/.aigit/update-check.json`) and prints a notice after the command finishes when a
+newer version is available. Set `AIGIT_NO_UPDATE_CHECK=1` to disable it.

--- a/README_CN.md
+++ b/README_CN.md
@@ -6,10 +6,13 @@
 
 ## 支持的大模型/AI
 
-- [OpenAI](https://openai.com/)
-- [DeepSeek](https://deepseek.com/)
-- [Doubao (豆包)](https://www.volcengine.com/product/doubao) - 内置，您不需要自己携带 API Key
-- [Gemini](https://gemini.google.com/)
+| 提供商 | 默认模型 |
+|---|---|
+| [OpenAI](https://openai.com/) | `gpt-5.4-mini` |
+| [DeepSeek](https://deepseek.com/) | `deepseek-v4-flash-260425` |
+| [Doubao (豆包)](https://www.volcengine.com/product/doubao) - 内置，您不需要自己携带 API Key | `doubao-seed-2-0-lite-260428` |
+| [Gemini](https://gemini.google.com/) | `gemini-3.5-flash` |
+| [Qwen (通义千问)](https://www.aliyun.com/product/tongyi) | `qwen-plus` |
 
 ## 快速开始
 
@@ -102,13 +105,13 @@ Enter your choice (press Enter for default):
 $ aigit auth add gemini AIzaSyCb56bjWn02e2v4s_TxHMDnHbSJQSx_tu8
 Successfully added API key for gemini
 
-$ aigit auth add doubao 6e3e438c-a380-4ed5-b597-e01cb82bc4df ep-20250110202503-fdkgq
+$ aigit auth add doubao 6e3e438c-a380-4ed5-b597-e01cb82bc4df
 Successfully added API key for doubao
 
 $ aigit auth ls
 Configured providers:
-  gemini *default
-  doubao
+  gemini(gemini-3.5-flash) *default
+  doubao(doubao-seed-2-0-lite-260428)
 
 $ aigit commit
 
@@ -159,3 +162,15 @@ The following changes were made:
 Enter your choice (press Enter for default): 1
 
 ✅ Successfully committed changes!
+```
+
+豆包提供商默认使用内置模型。您也可以选择传入[方舟推理接入点 ID](https://www.volcengine.com/docs/82379/1099522)（`ep-xxx`）或模型 ID 来覆盖默认模型：
+
+```shell
+$ aigit auth add doubao <api_key> ep-20250110202503-fdkgq
+```
+
+## 版本更新检查
+
+aigit 会在后台检查新版本（每 24 小时最多一次，结果缓存在 `~/.aigit/update-check.json`），
+当有新版本可用时，会在命令执行结束后打印升级提示。设置 `AIGIT_NO_UPDATE_CHECK=1` 可以禁用该功能。

--- a/llm/model.go
+++ b/llm/model.go
@@ -264,7 +264,7 @@ func generateDeepseekCommitMessage(diff, apiKey string) (string, error) {
 	ctx := context.Background()
 	prompt := fmt.Sprintf("%s\n%s", llmPrompt, diff)
 
-	reqBody := map[string]interface{}{
+	reqBody := map[string]any{
 		"model": deepseekModel,
 		"messages": []map[string]string{
 			{
@@ -298,14 +298,14 @@ func generateDeepseekCommitMessage(diff, apiKey string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return "", fmt.Errorf("decoding response: %w", err)
 	}
 
-	if choices, ok := result["choices"].([]interface{}); ok && len(choices) > 0 {
-		if choice, ok := choices[0].(map[string]interface{}); ok {
-			if message, ok := choice["message"].(map[string]interface{}); ok {
+	if choices, ok := result["choices"].([]any); ok && len(choices) > 0 {
+		if choice, ok := choices[0].(map[string]any); ok {
+			if message, ok := choice["message"].(map[string]any); ok {
 				if content, ok := message["content"].(string); ok {
 					return content, nil
 				}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/manifoldco/promptui"
@@ -17,10 +18,26 @@ import (
 var Version = "dev"
 
 func main() {
+	var updateNotice <-chan string
 	rootCmd := &cobra.Command{
 		Use:   "aigit",
 		Short: "Generate git commit message including title and body",
 		Long:  `AI Git Commi streamlines the git commit process by automatically generating meaningful and standardized commit messages.`,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			updateNotice = startUpdateCheck(Version)
+		},
+		PersistentPostRun: func(cmd *cobra.Command, args []string) {
+			select {
+			case notice := <-updateNotice:
+				if notice != "" {
+					fmt.Println(notice)
+				}
+			// Slightly longer than the update check's HTTP timeout so the
+			// once-per-day refresh can finish and persist its state file;
+			// cached runs deliver instantly.
+			case <-time.After(3 * time.Second):
+			}
+		},
 	}
 
 	authCmd := &cobra.Command{

--- a/update.go
+++ b/update.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+)
+
+const (
+	updateCheckInterval = 24 * time.Hour
+	latestReleaseURL    = "https://api.github.com/repos/agentsdance/aigit/releases/latest"
+)
+
+// updateCheckState is persisted to ~/.aigit/update-check.json so the
+// GitHub API is queried at most once per updateCheckInterval.
+type updateCheckState struct {
+	CheckedAt     time.Time `json:"checked_at"`
+	LatestVersion string    `json:"latest_version"`
+}
+
+// startUpdateCheck looks for a newer aigit release in the background while
+// the main command runs. The returned channel always delivers exactly one
+// value: an upgrade notice, or "" when no upgrade is available.
+func startUpdateCheck(current string) <-chan string {
+	ch := make(chan string, 1)
+	go func() {
+		ch <- updateNotice(current)
+	}()
+	return ch
+}
+
+func updateNotice(current string) string {
+	// Source builds report "dev" and have no release to compare against.
+	if current == "dev" || os.Getenv("AIGIT_NO_UPDATE_CHECK") != "" || os.Getenv("CI") != "" {
+		return ""
+	}
+
+	latest, err := latestVersion()
+	if err != nil || latest == "" {
+		return ""
+	}
+	if !versionLess(current, latest) {
+		return ""
+	}
+
+	return fmt.Sprintf("\n%s %s → %s\nTo upgrade: brew upgrade aigit  (or: go install github.com/zzxwill/aigit@latest)",
+		color.YellowString("A new release of aigit is available:"),
+		strings.TrimPrefix(current, "v"),
+		strings.TrimPrefix(latest, "v"))
+}
+
+// latestVersion returns the most recent release tag, served from the local
+// state file when it is fresh enough, otherwise from the GitHub API.
+func latestVersion() (string, error) {
+	stateFile := updateStateFile()
+	if stateFile != "" {
+		if st, err := readUpdateState(stateFile); err == nil && time.Since(st.CheckedAt) < updateCheckInterval {
+			return st.LatestVersion, nil
+		}
+	}
+
+	tag, err := fetchLatestTag()
+	if err != nil {
+		return "", err
+	}
+	if stateFile != "" {
+		writeUpdateState(stateFile, tag)
+	}
+	return tag, nil
+}
+
+func updateStateFile() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	dir := filepath.Join(homeDir, ".aigit")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return ""
+	}
+	return filepath.Join(dir, "update-check.json")
+}
+
+func readUpdateState(path string) (updateCheckState, error) {
+	var st updateCheckState
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return st, err
+	}
+	err = json.Unmarshal(data, &st)
+	return st, err
+}
+
+func writeUpdateState(path, latest string) {
+	data, err := json.Marshal(updateCheckState{CheckedAt: time.Now(), LatestVersion: latest})
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0o600)
+}
+
+func fetchLatestTag() (string, error) {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(latestReleaseURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %s", resp.Status)
+	}
+
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", err
+	}
+	return release.TagName, nil
+}
+
+// versionLess reports whether version a is older than version b. Versions
+// are compared numerically segment by segment ("v" prefix and pre-release
+// suffixes like "-rc1" are ignored), e.g. v0.0.9 < v0.0.10.
+func versionLess(a, b string) bool {
+	as := versionSegments(a)
+	bs := versionSegments(b)
+	for i := 0; i < len(as) || i < len(bs); i++ {
+		var av, bv int
+		if i < len(as) {
+			av = as[i]
+		}
+		if i < len(bs) {
+			bv = bs[i]
+		}
+		if av != bv {
+			return av < bv
+		}
+	}
+	return false
+}
+
+func versionSegments(v string) []int {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	parts := strings.Split(v, ".")
+	segs := make([]int, 0, len(parts))
+	for _, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			break
+		}
+		segs = append(segs, n)
+	}
+	return segs
+}

--- a/update_test.go
+++ b/update_test.go
@@ -1,0 +1,54 @@
+package main
+
+import "testing"
+
+func TestVersionLess(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want bool
+	}{
+		{"v0.1.1", "v0.1.2", true},
+		{"v0.1.2", "v0.1.1", false},
+		{"v0.1.2", "v0.1.2", false},
+		{"0.1.1", "v0.1.2", true},
+		{"v0.0.9", "v0.0.10", true},
+		{"v0.9.9", "v0.10.0", true},
+		{"v0.1.1-7-ga98bc1b", "v0.1.2", true},
+		{"v0.1.2-1-gb18cab4", "v0.1.2", false},
+		{"v1.0.0-rc1", "v1.0.0", false},
+		{"v0.1", "v0.1.1", true},
+		{"v1.0.0", "v2.0.0", true},
+	}
+	for _, tt := range tests {
+		if got := versionLess(tt.a, tt.b); got != tt.want {
+			t.Errorf("versionLess(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestVersionSegments(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []int
+	}{
+		{"v0.1.2", []int{0, 1, 2}},
+		{"0.1.2", []int{0, 1, 2}},
+		{"v0.1.1-7-ga98bc1b", []int{0, 1, 1}},
+		{"v1.0.0+build5", []int{1, 0, 0}},
+		{" v2.3.4 ", []int{2, 3, 4}},
+		{"garbage", []int{}},
+	}
+	for _, tt := range tests {
+		got := versionSegments(tt.in)
+		if len(got) != len(tt.want) {
+			t.Errorf("versionSegments(%q) = %v, want %v", tt.in, got, tt.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Errorf("versionSegments(%q) = %v, want %v", tt.in, got, tt.want)
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on #46 (includes its commit until it merges).

**Docs (EN + CN):**
- Provider list now a table including Qwen (previously undocumented) with each provider's current default model
- Doubao `auth add` example no longer shows a required endpoint ID; documents the optional `ep-xxx`/model-ID override
- `auth ls` sample output updated to the new `provider(model)` format
- New section documenting the automatic update check and `AIGIT_NO_UPDATE_CHECK=1` opt-out
- Fixed an unclosed code fence at the end of README_CN.md

**Code:**
- Add offline unit tests for `versionLess`/`versionSegments` (covers `v0.0.9 < v0.0.10`, git-describe suffixes, malformed input)
- Replace `interface{}` with `any` in `llm/model.go`

## Test plan

- `go test ./...` passes (new tests run offline; the Doubao live test skips without `ARK_API_KEY`)
- `gofmt` clean, `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)