### PR TITLE
feat(update): interactive self-upgrade when a new release is found

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,5 +179,7 @@ $ aigit auth add doubao <api_key> ep-20250110202503-fdkgq
 ## Update check
 
 aigit checks for new releases in the background (at most once every 24 hours, cached
-in `~/.aigit/update-check.json`) and prints a notice after the command finishes when a
-newer version is available. Set `AIGIT_NO_UPDATE_CHECK=1` to disable it.
+in `~/.aigit/update-check.json`). When a newer version is available, it asks after the
+command finishes whether to upgrade; if you agree, aigit upgrades itself in place
+(via Homebrew for brew installs, otherwise by building the release from source).
+Set `AIGIT_NO_UPDATE_CHECK=1` to disable the check.

--- a/README_CN.md
+++ b/README_CN.md
@@ -172,5 +172,7 @@ $ aigit auth add doubao <api_key> ep-20250110202503-fdkgq
 
 ## 版本更新检查
 
-aigit 会在后台检查新版本（每 24 小时最多一次，结果缓存在 `~/.aigit/update-check.json`），
-当有新版本可用时，会在命令执行结束后打印升级提示。设置 `AIGIT_NO_UPDATE_CHECK=1` 可以禁用该功能。
+aigit 会在后台检查新版本（每 24 小时最多一次，结果缓存在 `~/.aigit/update-check.json`）。
+当有新版本可用时，会在命令执行结束后询问是否升级；如果您同意，aigit 会自动完成升级
+（Homebrew 安装的版本通过 brew 升级，其他安装方式则从源码构建新版本并原地替换）。
+设置 `AIGIT_NO_UPDATE_CHECK=1` 可以禁用该功能。

--- a/main.go
+++ b/main.go
@@ -28,10 +28,29 @@ func main() {
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
 			select {
-			case notice := <-updateNotice:
-				if notice != "" {
-					fmt.Println(notice)
+			case latest := <-updateNotice:
+				if latest == "" {
+					return
 				}
+				fmt.Printf("\n%s %s → %s\n",
+					color.YellowString("A new release of aigit is available:"),
+					strings.TrimPrefix(Version, "v"), strings.TrimPrefix(latest, "v"))
+				prompt := promptui.Select{
+					Label: "Upgrade now",
+					Items: []string{"Yes", "No"},
+					Size:  2,
+				}
+				// Non-interactive runs fail the prompt; skip silently.
+				choice, _, err := prompt.Run()
+				if err != nil || choice != 0 {
+					return
+				}
+				fmt.Println("⬆️  Upgrading aigit to", latest, "...")
+				if err := selfUpgrade(latest); err != nil {
+					color.Red("Upgrade failed: %v", err)
+					return
+				}
+				color.Green("✅ aigit upgraded to %s", latest)
 			// Slightly longer than the update check's HTTP timeout so the
 			// once-per-day refresh can finish and persist its state file;
 			// cached runs deliver instantly.

--- a/update.go
+++ b/update.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/fatih/color"
 )
 
 const (
@@ -27,16 +25,16 @@ type updateCheckState struct {
 
 // startUpdateCheck looks for a newer aigit release in the background while
 // the main command runs. The returned channel always delivers exactly one
-// value: an upgrade notice, or "" when no upgrade is available.
+// value: the tag of the newer release, or "" when no upgrade is available.
 func startUpdateCheck(current string) <-chan string {
 	ch := make(chan string, 1)
 	go func() {
-		ch <- updateNotice(current)
+		ch <- newerRelease(current)
 	}()
 	return ch
 }
 
-func updateNotice(current string) string {
+func newerRelease(current string) string {
 	// Source builds report "dev" and have no release to compare against.
 	if current == "dev" || os.Getenv("AIGIT_NO_UPDATE_CHECK") != "" || os.Getenv("CI") != "" {
 		return ""
@@ -50,10 +48,7 @@ func updateNotice(current string) string {
 		return ""
 	}
 
-	return fmt.Sprintf("\n%s %s → %s\nTo upgrade: brew upgrade aigit  (or: go install github.com/zzxwill/aigit@latest)",
-		color.YellowString("A new release of aigit is available:"),
-		strings.TrimPrefix(current, "v"),
-		strings.TrimPrefix(latest, "v"))
+	return latest
 }
 
 // latestVersion returns the most recent release tag, served from the local

--- a/upgrade.go
+++ b/upgrade.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const repoURL = "https://github.com/agentsdance/aigit"
+
+// selfUpgrade replaces the running binary with the given release version.
+// Homebrew installs are delegated to brew; everything else is built from the
+// release tag with the local Go toolchain and swapped in place.
+func selfUpgrade(version string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locating current binary: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+
+	if strings.Contains(exe, "/Cellar/") || strings.Contains(exe, "/linuxbrew/") {
+		cmd := exec.Command("brew", "upgrade", "aigit")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	}
+
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		return fmt.Errorf("go toolchain not found; cannot build %s from source", version)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "aigit-upgrade-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcDir := filepath.Join(tmpDir, "src")
+	if err := runQuiet(exec.Command("git", "clone", "--quiet", "--depth", "1", "--branch", version, repoURL, srcDir)); err != nil {
+		return fmt.Errorf("downloading %s: %w", version, err)
+	}
+
+	newBin := filepath.Join(tmpDir, "aigit")
+	build := exec.Command(goBin, "build", "-ldflags", "-s -w -X main.Version="+version, "-o", newBin, ".")
+	build.Dir = srcDir
+	if err := runQuiet(build); err != nil {
+		return fmt.Errorf("building %s: %w", version, err)
+	}
+
+	return replaceBinary(newBin, exe)
+}
+
+// replaceBinary swaps dst for newBin via a rename from a sibling temp file,
+// so the running executable is replaced atomically rather than truncated.
+func replaceBinary(newBin, dst string) error {
+	data, err := os.ReadFile(newBin)
+	if err != nil {
+		return err
+	}
+	staged := dst + ".new"
+	if err := os.WriteFile(staged, data, 0o755); err != nil {
+		return fmt.Errorf("staging new binary (try upgrading with elevated permissions): %w", err)
+	}
+	if err := os.Rename(staged, dst); err != nil {
+		os.Remove(staged)
+		return fmt.Errorf("installing new binary: %w", err)
+	}
+	return nil
+}
+
+func runQuiet(cmd *exec.Cmd) error {
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- The update notice no longer prints manual upgrade commands; instead it asks `Upgrade now: Yes/No`
- On Yes, aigit upgrades itself in place:
  - Homebrew installs (binary under `/Cellar/` or linuxbrew) delegate to `brew upgrade aigit`
  - All other installs: shallow-clone the release tag, build with the local Go toolchain (`-X main.Version=<tag>` stamped), and atomically swap the running binary via a sibling temp file + rename
- Non-interactive runs (no TTY) skip the prompt silently; declining leaves everything untouched; failures (no Go toolchain, no write permission) report a clear error without breaking the binary

## Test plan

- Live end-to-end: a `v0.1.2`-stamped binary discovered the real v0.1.3 release, prompted, and on Yes rebuilt and replaced itself — `aigit version` then reported `v0.1.3`
- Non-interactive (stdin EOF): exits cleanly, no hang, no upgrade
- `go build ./...`, `go test ./...`, `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)